### PR TITLE
Keep every checkout on LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Every tracked file in the working tree had been rewritten to CRLF, which showed up as 8,633 changed lines across 25 files with no content change behind any of them.

The cause is a Windows clone. Git on Windows stores LF blobs but caches the CRLF file size in the index, so `go.mod` carried `size: 906` against a blob whose LF content is 879 bytes. Moved to Linux, every file read as modified — and because `ie_modified()` short-circuits on a size mismatch without hashing, `git status` reported the files dirty while `git diff` showed nothing.

`* text=auto eol=lf` pins the checkout to LF whatever platform does the cloning, so the phantom diff cannot come back.

No tracked content changes: the blobs on `main` were already LF, and `git diff --ignore-cr-at-eol` was empty before and after.
