### PR TITLE
Harden account request boundaries

### DIFF
--- a/API.md
+++ b/API.md
@@ -4,7 +4,7 @@ This document is the complete closed request and response schema contract for
 the Go API. The generated [OpenAPI inventory](./openapi/openapi.json) is the
 source of truth for route and method enumeration, authentication and CSRF
 classes, availability, and Go handler ownership. Regenerate it with
-`npm run openapi:generate` from this directory; backend CI compares it byte for
+`npm run openapi:generate` from this directory; server CI compares it byte for
 byte.
 
 The API is vault-blind. These contracts must never carry a vault file,
@@ -317,10 +317,19 @@ usable:
   an already-approved device. The service cannot produce this package, which is
   what makes "Sesame cannot add a device to your vault" a property rather than a
   promise.
-- `DELETE /v1/sync/devices/{id}` → revokes a device and advances the vault
-  epoch, invalidating envelopes signed under the previous epoch.
+- `POST /v1/sync/devices/{id}/deny` → removes a pending device, which never had
+  the vault key and therefore needs no key rotation.
+- `POST /v1/sync/devices/{id}/rekey` → removes another approved device while
+  atomically advancing the vault epoch, replacing the encrypted envelope, and
+  supplying new encrypted key packages for every survivor.
+- `DELETE /v1/sync/devices/{id}` → lets only the calling device leave the
+  vault. Removing another approved device requires the signed rekey ceremony.
 - `GET /v1/sync/key-package?deviceId=` → the wrapped vault key addressed to one
   device.
+- `POST /v1/sync/activate` → proves that an approved device received its key
+  package before making it active.
+- `POST /v1/sync/reset` → deletes an abandoned synced vault only when no
+  approved device remains.
 - `GET /v1/sync/envelope` → current revision and opaque ciphertext.
 - `POST /v1/sync/envelope` → compare-and-swap upload. Returns
   `409 sync_conflict` with the current revision when another device got there

--- a/README.md
+++ b/README.md
@@ -1,29 +1,37 @@
 # Sesame Go API
 
-This service is vault-blind by design. It publishes public product plans, product status, release availability, support status, and the server boundary. Its separate website account has four jobs: beta eligibility, signed-download access, licence metadata, and website/desktop device management. Payment processing and offline licence issuance are not implemented.
+This is a vault-blind account service. It publishes product, release, and
+support metadata. It also provides website accounts, beta eligibility,
+download metadata, desktop linking, and support requests. It does not process
+payments or issue offline licences.
 
-It must never accept vault passwords, TOTP seeds, recovery details, import files, encrypted vaults, or encryption keys. Website-account passwords are an explicit exception: they are Argon2id-hashed before storage and are not connected to a local vault.
+The service never accepts a vault password, TOTP seed, recovery detail, import
+file, encrypted vault, or encryption key. Website-account passwords are the
+only exception. They are Argon2id-hashed and are not connected to a vault.
 
-Metadata endpoints are read-only and reject every request body without parsing or logging it. Account endpoints use small, route-specific JSON schemas, store Argon2id password hashes and hashed opaque tokens, and reject unknown or vault-shaped fields. There is no vault endpoint.
+Metadata endpoints are read-only. They reject request bodies without parsing
+or logging them. Account endpoints use small, route-specific JSON schemas and
+reject unknown or vault-shaped fields. There is no vault endpoint.
 
-The desktop-link flow is separate: a signed-in website account creates a one-time code that expires after ten minutes. The installed Windows app redeems it directly with the API and receives its own opaque device token. The token is stored locally under the current Windows profile. This links only the account service; it does not upload, identify, or unlock a vault, and it does not enable Sync.
+A signed-in account can create a one-time desktop-link code. It expires after
+ten minutes. The installed Windows app redeems it directly with the API and
+receives an opaque device token. The token links the account service only. It
+does not upload, identify, or unlock a vault, and it does not enable Sync.
 
 ## Self-hosting
 
-One flow, from a fresh clone, with no Sesame-owned key, domain, or account:
+From a fresh clone:
 
 ```bash
-npm install
+npm ci
 npm run setup
 npm run compose:up
 ```
 
-`npm run setup` writes this deployment's own database password, capability
-signing key, admin encryption key, and admin IP pepper into the gitignored
-`deploy/compose/.env`, and resolves the build contexts for the API and both
-portals. Re-running keeps every existing value, because rotating the admin
-encryption key locks out administrators whose MFA secret was written under the
-old one.
+`npm run setup` writes local secrets to the gitignored
+`deploy/compose/.env`. It also resolves the build contexts for the API and both
+portals. It keeps existing values on later runs. Rotating the admin encryption
+key makes existing MFA secrets unreadable.
 
 `npm run compose:up` starts PostgreSQL, applies migrations, and runs the API,
 the account portal, the administration portal, and a local mail catcher:
@@ -41,11 +49,9 @@ Then create the first administrator, which prints a one-time setup link:
 npm run admin:bootstrap -- bootstrap you@example.com
 ```
 
-Registration defaults to `invite`. Once an admin store exists, which this
-deployment always has, the `registration_mode` feature flag in the database is
-what the API reads: `SESAME_REGISTRATION_MODE` applies only to a deployment
-running without administration. Change it from the administration portal, or
-issue invitations from there.
+Registration defaults to `invite`. Deployments with administration use the
+database `registration_mode` flag. `SESAME_REGISTRATION_MODE` applies only
+without administration. Change the flag or issue invitations in the portal.
 
 The public marketing site is not part of this deployment and is not required
 by it. If you run one, set `SESAME_PUBLIC_SITE_ORIGIN` to its origin: it may
@@ -56,53 +62,23 @@ Everything above runs over HTTP on loopback. Behind TLS, set
 `SESAME_SESSION_SECURE` and `SESAME_ADMIN_SESSION_SECURE` to `true` and give
 each origin its real HTTPS address.
 
-## Run locally in the monorepo
+## Local configuration
 
-The API and website are separate processes. Run both from the repository root.
+Use the self-hosting flow above for local development too. `npm run setup`
+must run before Compose because it creates deployment-specific secrets and
+build contexts in `deploy/compose/.env`. That file is for local development
+only. The complete API configuration template is [.env.example](.env.example),
+and the production Compose values are documented in
+[DEPLOYMENT.md](DEPLOYMENT.md).
 
-```powershell
-npm run api:up
-```
+The default API address is `127.0.0.1:8787`. Compose also starts a local
+Mailpit inbox at `http://localhost:8025`, so verification and recovery mail can
+be tested without an external provider. It is a development-only capture
+service.
 
-This starts PostgreSQL and the API on `http://localhost:8787`, generating the local secrets in the gitignored root `.env` first if they are missing. It is the only supported way to start the stack, because a Compose command that skips that step can leave `SESAME_ADMIN_ENCRYPTION_KEY` out of step with the database. The Compose credentials are local-development-only. Do not also run `npm run backend:dev` while the Compose API is using port 8787.
-
-For native API development, run:
-
-```powershell
-npm run backend:dev
-```
-
-When `DATABASE_URL` is unset, this command stops the containerized API, starts
-the PostgreSQL service from `compose.yaml`, waits for it to become healthy, and
-supplies the explicit development-only connection string to the Go process.
-The database is exposed on `127.0.0.1:5432`, never on the network interface.
-Production still fails closed when `DATABASE_URL` is missing. Set
-`DATABASE_URL` yourself to use an existing PostgreSQL instance; in that case
-Docker is not touched.
-
-The default address is `127.0.0.1:8787`. Compose also starts a local Mailpit
-inbox at `http://localhost:8025`, so verification and recovery mail can be
-tested without an external provider. It is a development-only capture service.
-
-Configuration:
-
-- `SESAME_API_ADDR`
-- `SESAME_API_VERSION`
-- `SESAME_WEB_ORIGIN`
-- `DATABASE_URL`
-- `SESAME_SESSION_SECURE` (`false` for local HTTP only)
-- `SESAME_SESSION_DOMAIN` (optional cookie domain)
-- `SESAME_REGISTRATION_MODE` (`closed`, `invite`, or `public`; defaults to `invite`)
-- `SESAME_SMTP_ADDR` (`host:port`; when set, STARTTLS is mandatory)
-- `SESAME_SMTP_USERNAME`
-- `SESAME_SMTP_PASSWORD`
-- `SESAME_SMTP_FROM`
-
-`SESAME_SMTP_ALLOW_INSECURE_LOCAL=true` is permitted only with
-`SESAME_ENV=development`, has no SMTP credentials, and is used only for the
-isolated local Mailpit container. Every other SMTP configuration requires
-STARTTLS.
-- `SESAME_RP_ID` and `SESAME_RP_NAME` (website passkeys)
+`SESAME_SMTP_ALLOW_INSECURE_LOCAL=true` is accepted only with
+`SESAME_ENV=development` and no SMTP credentials. Every other SMTP
+configuration requires STARTTLS.
 
 `invite` mode accepts either a row in `sesame_beta_eligibility` with status
 `eligible`, or a live single-use value in `sesame_beta_invites`. Invite values
@@ -131,7 +107,7 @@ The API process (`cmd/api`) opens the database without migrating and will exit
 if the schema is not current. This prevents multiple replicas from racing to
 apply the same migrations and keeps deployment rollback simple.
 
-The root Compose stack runs the `migrate` job after PostgreSQL is healthy and
+The Compose stack runs the `migrate` job after PostgreSQL is healthy and
 before the API starts. Production deployments should run the same
 `cmd/migrate` job once per release before starting API replicas.
 
@@ -163,17 +139,15 @@ npm ci
 npm run ci
 ```
 
-The `backend/` subtree owns its Node and Go command wrappers, lockfile, build,
-vet, race-test, vulnerability, generated OpenAPI, and future CI entry points.
+This repository owns its Node and Go command wrappers, lockfile, build, vet,
+race-test, vulnerability scan, generated OpenAPI inventory, and CI workflow.
 `npm run openapi:generate` regenerates `openapi/openapi.json` from the Go mux
 registrations; `npm run openapi:check` fails if that checked-in inventory is
-stale or incomplete. Copying the exact
-subtree into an empty directory does not require a desktop, website, admin, or
-extension checkout. PostgreSQL integration cases run when
-`SESAME_TEST_DATABASE_URL` is set and otherwise skip; the future CI workflow
-supplies a fictional test database. The root Compose flow remains the only
-supported local stack entry point because it generates local secrets before
-starting services.
+stale or incomplete. A checkout does not require the desktop, public website,
+or browser extension. PostgreSQL integration cases run when
+`SESAME_TEST_DATABASE_URL` is set and otherwise skip; CI supplies a fictional
+test database. The Compose flow remains the supported local stack entry point
+because setup generates local secrets before starting services.
 
 Card processing remains deliberately outside Sesame. A regulated provider must
 handle card data; Sesame records only its internal entitlement and receipt
@@ -181,9 +155,10 @@ references after a verified provider event.
 
 ## Account boundary and API
 
-The website account exists for four jobs only: beta eligibility, access to
-signed downloads, licence metadata, and browser/desktop device management. It
-does not identify, receive, sync, or unlock a local vault.
+The website account owns authentication, account and session management, beta
+eligibility, signed-download and licence metadata, desktop linking, notification
+preferences, and support history. It does not identify, receive, sync, or
+unlock a local vault.
 
 See [openapi/openapi.json](./openapi/openapi.json) for the generated endpoint,
 method, authentication/CSRF, availability, and handler-ownership inventory.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,12 @@
 # Security policy
 
 This repository holds the Sesame server: the vault-blind Go API, the account
-portal, and the administration portal. It is part of a password manager in
-private beta and has not had an independent security audit.
+portal, and the administration portal. It is early software and has not had an
+independent security audit.
 
-The rule this service exists to keep: it stores account records and opaque
-bytes. It has no vault endpoint and no vault-shaped type.
+The rule this service exists to keep: the shipping API stores account and
+release records, not vault data. The development-only Sync preview can store
+opaque ciphertext but has no decryption key.
 
 ## Reporting a vulnerability
 
@@ -56,8 +57,10 @@ In scope:
 
 Out of scope:
 
-- Sync. It is built-disabled, reachable from no route, and has its own open
-  findings recorded in the desktop repository. Report Sync issues there.
+- Sync remains unavailable in the shipping API. Its routes are registered but
+  fail closed because `cmd/api` does not provide a Sync store. A separate
+  loopback-only development binary can wire the preview store when
+  `SESAME_ENV=development`; report findings against that preview here.
 - Missing hardening with no demonstrated impact: header audits, version
   disclosure, rate limits without a working amplification, scanner output.
 - Denial of service through traffic volume, and social engineering.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -8,14 +8,19 @@ This file records the current boundary and the remaining release work. It is not
 
 ## Implemented
 
-### Website and account portal
+### Public website and account portal
 
-- Guests and signed-in users can create a request through `POST /v1/support/requests`.
+- The public website links to the account portal's support form when an account
+  origin is configured. It does not submit support content itself.
+- Guests and signed-in users can create a request through
+  `POST /v1/support/requests` from the account portal.
 - The API rejects attachment content types, unknown fields, oversized content, and common secret-shaped text before storing a request.
 - Intake is rate-limited and returns a reference number without exposing ticket contents publicly.
 - A signed-in user can list and read only requests owned by that account under `/v1/account/support/*`.
-- Signed-in users can add a follow-up to an open request. Closed requests cannot be reopened by the requester.
-- The website repeats the no-secrets boundary before intake and follow-up submission.
+- Signed-in users can add a follow-up to an open request, close it, and reopen
+  it for 30 days after closure.
+- Both sites repeat the no-secrets boundary before directing or submitting a
+  request.
 
 ### Desktop app
 
@@ -32,26 +37,36 @@ This file records the current boundary and the remaining release work. It is not
 - Internal notes are never exposed through the account portal.
 - Admin mutations use the same fail-closed audit transaction as the rest of the control plane. If the audit write fails, the support mutation fails.
 - Replies and notes pass the secret-shaped-content guard before storage.
+- A staff reply queues a short notification email only when the owning account
+  opted in to support-reply notifications and SMTP is configured. The email
+  links to the portal and never contains the reply body.
 - Read-only and unrelated admin roles cannot mutate support data.
 
 ### Database
 
 - Migration `0008_support_workspace.sql` adds conversation messages, internal notes, assignment, priority, timestamps, and the `open | in_progress | waiting | closed` workflow.
 - Migration `0009_support_portal.sql` aligns new intake with the workspace and account portal.
+- Migration `0019_support_lifecycle.sql` adds unread state, the bounded reopen
+  window, and durable email-delivery linkage. Migration
+  `0028_support_ticket_category.sql` adds the triage category.
 - Ticket ownership is tied to the website account when the requester is signed in. A guest reference number is not an authentication credential.
 
 ## Delivery status
 
-Staff replies are visible in the signed-in website portal. Outbound email delivery for support replies is **not implemented** and must not be described as sent. Account-action mail for verification and recovery is a separate SMTP-backed system.
+Staff replies are visible in the signed-in account portal. When the account
+has opted in and SMTP is configured, a durable outbox delivers a notification
+that a reply is waiting. The worker records pending, delivered, and failed
+states with bounded retries. Portal visibility does not depend on email
+delivery, and no notification contains the support message.
 
 The public support flow is suitable for controlled beta testing, not a promise of continuous support. There is no attachment handling, live chat, phone support, automatic desktop-log upload, or vault recovery service.
 
 ## Release checks still required
 
-- Run migrations `0001` through `0009` against a fresh PostgreSQL database and an upgrade fixture.
+- Run every checked-in migration against a fresh PostgreSQL database and an
+  upgrade fixture.
 - Add end-to-end tests with the real website, API, admin app, and PostgreSQL for guest intake, account ownership, follow-up, assignment, notes, status changes, and audit failure.
 - Verify rate limits and secret-shape rejection without logging rejected content.
-- Remove or disable any UI that claims a support reply was emailed until a real delivery result is recorded.
 - Define retention, deletion, abuse handling, response expectations, and incident escalation before public launch.
 - Exercise keyboard navigation, focus restoration, Narrator, 200% zoom, and narrow layouts in both support interfaces.
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -80,6 +80,10 @@ func main() {
 	adminOrigin := ""
 	adminSecure := envBool("SESAME_ADMIN_SESSION_SECURE", sessionSecure)
 	adminIPPepper := strings.TrimSpace(os.Getenv("SESAME_ADMIN_IP_PEPPER"))
+	if adminIPPepper == "" {
+		slog.Error("Sesame API configuration is invalid", "error", "SESAME_ADMIN_IP_PEPPER is required because identity rate-limit keys are peppered with it")
+		os.Exit(1)
+	}
 	if adminKeyValue != "" {
 		var originErr error
 		adminOrigin, originErr = configuredOrigin("SESAME_ADMIN_ORIGIN")
@@ -94,10 +98,6 @@ func main() {
 		}
 		if strings.HasPrefix(adminOrigin, "https://") && !adminSecure {
 			slog.Error("Sesame admin configuration is invalid", "error", "Secure admin cookies are required for an HTTPS admin origin")
-			os.Exit(1)
-		}
-		if adminIPPepper == "" {
-			slog.Error("Sesame admin configuration is invalid", "error", "SESAME_ADMIN_IP_PEPPER is required when the admin service is enabled")
 			os.Exit(1)
 		}
 		adminService, err = adminstore.Open(ctx, databaseURL, adminKey)

--- a/internal/httpapi/request_security.go
+++ b/internal/httpapi/request_security.go
@@ -277,13 +277,25 @@ func (a *api) notFound(response http.ResponseWriter, request *http.Request) {
 
 func (a *api) clientIP(request *http.Request) string {
 	peer := requestIP(request)
-	if a.isTrustedProxy(peer) {
-		if forwarded := request.Header.Get("X-Forwarded-For"); forwarded != "" {
-			first := strings.TrimSpace(strings.SplitN(forwarded, ",", 2)[0])
-			if ip, err := netip.ParseAddr(first); err == nil {
-				return ip.Unmap().String()
-			}
+	if !a.isTrustedProxy(peer) {
+		return peer
+	}
+	forwarded := request.Header.Get("X-Forwarded-For")
+	if forwarded == "" {
+		return peer
+	}
+	hops := strings.Split(forwarded, ",")
+	for index := len(hops) - 1; index >= 0; index-- {
+		hop := strings.TrimSpace(hops[index])
+		ip, err := netip.ParseAddr(hop)
+		if err != nil {
+			return peer
 		}
+		ip = ip.Unmap()
+		if a.isTrustedProxy(ip.String()) {
+			continue
+		}
+		return ip.String()
 	}
 	return peer
 }

--- a/internal/httpapi/support_intake.go
+++ b/internal/httpapi/support_intake.go
@@ -86,6 +86,9 @@ func (a *api) createSupportRequest(response http.ResponseWriter, request *http.R
 	if cookie, err := request.Cookie(a.sessionCookieName()); err == nil && cookie.Value != "" {
 		if user, err := a.config.Accounts.UserBySession(request.Context(), accounts.HashSessionToken(cookie.Value)); err == nil {
 			accountID = user.ID
+			if accountEmail, ok := normalizedEmail(user.Email); ok {
+				email = accountEmail
+			}
 		}
 	}
 	id, err := store.CreateSupportRequest(request.Context(), accounts.SupportRequest{

--- a/web/admin/README-ADMIN.md
+++ b/web/admin/README-ADMIN.md
@@ -1,427 +1,128 @@
 # Sesame administration app
 
-This document records shipped behaviour. All of the following are implemented:
-the separate frontend, admin-only authentication and sessions, CLI bootstrap,
-role checks, user actions, feature flags, releases, plans, administrator
-management, system views, vault-shaped body rejection, and the transactional
-audit log.
+This document describes the current administration boundary. The Svelte portal
+is in `web/admin`. Its handlers are in `internal/httpapi/admin_*.go`; its store
+and authorization model are in `internal/admin`.
 
-Two parts are deliberately left un-automated. Trusted proxy ranges stay
-deployment-controlled, since changing which network peers may assert a client
-address needs a controlled restart. Administrator invitations return a
-one-time setup URL for a super administrator to hand over through a trusted
-channel rather than being emailed.
+The administration app manages website accounts, support requests, runtime
+controls, releases, product plans, and administrators. It cannot receive,
+open, reset, identify, or decrypt a local vault.
 
-A separate web application for staff to manage accounts, devices, releases, feature flags, and product configuration. It runs on the same Go API, yet uses a separate auth boundary, role system, and audit log. It never receives vault data.
+## Run and validate
 
-During the Phase 1 repository boundary work, the `admin/` subtree is
-independently buildable. It owns its package lock, Node version, commands, lint
-and TypeScript configuration, design-token snapshot, browser tests, and future
-CI entry point. Root commands are wrappers around those owned commands. Copying
-the exact subtree into an empty directory and running `npm ci` followed by
-`npm --prefix . run ci` needs no desktop, website, extension, root design file,
-or root package metadata. This packaging change does not alter admin authentication,
-authorization, audit, CSP, CORS, or separate-origin deployment.
+From `web/admin`:
 
-## Architecture
-
-### Separate app, shared API
-
-```
-admin.usesesame.app  (or usesesame.app/admin)
-         |
-         | HTTPS + admin session cookie + CSRF
-         v
-  Go API (/v1/admin/*)
-  - Separate admin auth, not shared with user accounts
-  - Separate session table, shorter TTL (8h)
-  - MFA required (TOTP or WebAuthn)
-  - All actions audited
-  - Vault-blind: same prohibited-data rules as the public API
-         |
-         v
-  PostgreSQL (shared with public API)
-  - New tables: sesame_admin_accounts, sesame_admin_sessions,
-    sesame_admin_audit_log, sesame_feature_flags
-  - Existing tables: sesame_accounts (read + limited write),
-    sesame_desktop_connections (read + revoke)
+```powershell
+npm ci
+$env:VITE_SESAME_API_URL='https://api.test.invalid'
+npm run release:check
 ```
 
-### Why a separate app, not a route in the marketing website
+`npm run ci` runs design-token, lint, and type checks. `npm run release:check`
+also builds the production bundle and security headers. There are no browser
+specs yet, so `npm run test` prints a skip notice.
 
-The website (`website/`) is a public marketing surface with no privileged access. Folding admin capabilities into it would enlarge the attack surface of a public-facing SPA. A separate `admin/` frontend keeps the blast radius small, and gives the admin app its own CSP, its own deploy cadence, and its own auth flow that never touches the website's cookie domain.
+Start the complete server stack from the repository root:
 
-### Monorepo layout
-
-```
-admin/                    New Svelte SPA (same stack as website/)
-  src/
-  public/
-  package.json
-  vite.config.ts
-backend/
-  internal/
-    admin/                New Go package: admin store, roles, audit
-      admin.go
-      audit.go
-      roles.go
-      store.go
-      migrations/
-        0006_admin_dashboard.sql
-    httpapi/
-      admin_routes.go     New file: all /v1/admin/* handlers
-      admin_auth.go       New file: admin session middleware
+```powershell
+npm run setup
+npm run compose:up
 ```
 
-The admin frontend builds to static files and deploys to its own origin (`admin.usesesame.app`) or a subpath (`usesesame.app/admin`). It calls the same Go API, though only the `/v1/admin/*` routes.
+See [DEPLOYMENT.md](../../DEPLOYMENT.md) for deployment instructions.
 
-## Roles and permissions
+## Boundary decisions
 
-Five roles exist. A super admin assigns roles. Every role can read its own audit log entries.
+### Separate origin and session
 
-| Capability | Super Admin | Support | Operations | Billing | Read-only |
-|---|---|---|---|---|---|
-| View dashboard overview | yes | yes | yes | yes | yes |
-| List/search users | yes | yes | limited | limited | yes |
-| View user detail (email, devices, sessions, beta access) | yes | yes | limited | limited | yes |
-| Grant/revoke beta access | yes | yes | no | no | no |
-| Suspend/unsuspend account | yes | yes | no | no | no |
-| Delete account | yes | no | no | no | no |
-| Revoke user sessions | yes | yes | no | no | no |
-| Revoke user devices | yes | yes | no | no | no |
-| View audit log (all) | yes | own actions only | own actions only | own actions only | yes |
-| Manage feature flags | yes | no | yes | no | no |
-| Manage releases | yes | no | yes | no | no |
-| Manage product plans/pricing | yes | no | no | yes | no |
-| Manage trusted proxies / system config | yes | no | yes | no | no |
-| Manage admin accounts (invite, assign roles, revoke) | yes | no | no | no | no |
-| View rate-limit / health metrics | yes | yes | yes | no | yes |
+The administration portal has its own configured origin. `/v1/admin/*`
+accepts credentialed browser traffic only from that exact origin. Admin
+sessions use a separate cookie and table from website-account sessions, a
+separate CSRF token, and an eight-hour lifetime.
 
-### Role definitions
+The normal deployment uses `admin.usesesame.app`. Serving it from the public
+website origin removes the origin boundary enforced by the API.
 
-**Super Admin.** Full access. Only this role can invite other admins, assign roles, and delete user accounts. Should be limited to 2-3 people.
+### Password plus TOTP
 
-**Support.** Day-to-day account assistance. Can search users, view details, grant/revoke beta access, suspend accounts, and revoke sessions and devices. Cannot delete accounts or touch product config. The audit log shows only their own actions.
+Every administrator signs in with a password and TOTP. There is no public
+administrator registration. `adminctl` creates the first super administrator
+and prints a one-time setup link. The link reveals its enrollment secret once.
+Setup must finish within 30 minutes. `adminctl reset` revokes sessions and
+issues a new link.
 
-**Operations.** Manages the product surface: feature flags, release metadata, trusted proxies, rate-limit config. Cannot touch user accounts or billing.
+`SESAME_ADMIN_ENCRYPTION_KEY` encrypts administrator TOTP secrets. Replacing
+that key makes existing secrets unreadable, so deployments must back it up
+separately from PostgreSQL.
 
-**Billing.** Manages plans, pricing, and (when Stripe is live) refund/licence operations. Cannot touch users or system config.
+### Authorization and audit
 
-**Read-only.** Auditor or observer. Can view everything but change nothing. Useful for stakeholders or external review.
+Authorization is enforced by `internal/admin/types.go`, not by hiding portal
+navigation. The current roles are:
 
-## Database schema
+| Role | Additional authority beyond its own audit entries |
+| --- | --- |
+| `super` | Every administration permission, including account deletion and administrator management |
+| `support` | Read and manage users and support requests |
+| `ops` | Manage feature flags and release controls; read system state |
+| `billing` | Read users and manage product plans |
+| `readonly` | Read all admin data and the full audit log |
 
-New migration `0006_admin_dashboard.sql`:
+Every administrative mutation writes an allowlisted audit record in the same
+database transaction. If the audit write fails, the change fails. Audit records
+are append-only through the API. Only `super` and `readonly` can read or export
+the full log. Other roles see their own entries.
 
-```sql
--- Admin accounts. Separate from sesame_accounts (user accounts).
--- An admin account is created by a super admin; there is no public
--- registration.
-CREATE TABLE IF NOT EXISTS sesame_admin_accounts (
-    id            TEXT PRIMARY KEY,
-    email         TEXT NOT NULL UNIQUE,
-    password_hash TEXT NOT NULL,
-    role          TEXT NOT NULL CHECK (role IN ('super', 'support', 'ops', 'billing', 'readonly')),
-    totp_secret   BYTEA,                    -- encrypted at rest, NULL until MFA is set up
-    totp_verified BOOLEAN NOT NULL DEFAULT FALSE,
-    suspended     BOOLEAN NOT NULL DEFAULT FALSE,
-    created_by    TEXT REFERENCES sesame_admin_accounts(id),
-    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    last_login_at TIMESTAMPTZ
-);
+Trusted proxy ranges are deployment configuration. The portal can read the
+effective system configuration but exposes no route that changes which peers
+may assert a client address.
 
-CREATE INDEX IF NOT EXISTS sesame_admin_accounts_role_idx
-    ON sesame_admin_accounts(role);
+### Vault-blind control plane
 
--- Admin sessions. Short TTL (8h), HttpOnly + Secure + SameSite=Strict.
--- Token stored as SHA-256 hash only.
-CREATE TABLE IF NOT EXISTS sesame_admin_sessions (
-    token_hash   BYTEA PRIMARY KEY,
-    admin_id     TEXT NOT NULL REFERENCES sesame_admin_accounts(id) ON DELETE CASCADE,
-    ip_hash      TEXT,                       -- SHA-256 of IP for audit binding without retention
-    user_agent   TEXT,                       -- truncated to 200 chars
-    expires_at   TIMESTAMPTZ NOT NULL,
-    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
+Admin request bodies use closed schemas and reject vault-shaped fields. User
+views show website-account state, browser sessions, and desktop-link metadata.
+Release artifacts enter through the authenticated candidate pipeline. The
+portal controls rollout and publication; it does not create artifact evidence.
 
-CREATE INDEX IF NOT EXISTS sesame_admin_sessions_expiry_idx
-    ON sesame_admin_sessions(expires_at);
+## Domain model
 
--- Audit log. Append-only. Every admin action gets one row.
--- No user vault data is ever stored here.
-CREATE TABLE IF NOT EXISTS sesame_admin_audit_log (
-    id            BIGSERIAL PRIMARY KEY,
-    admin_id      TEXT NOT NULL REFERENCES sesame_admin_accounts(id),
-    admin_email   TEXT NOT NULL,             -- snapshot for readability after admin deletion
-    action        TEXT NOT NULL,             -- e.g. "user.suspend", "flag.update", "release.publish"
-    target_type   TEXT NOT NULL,             -- "account", "device", "flag", "release", "admin", "plan"
-    target_id     TEXT,                      -- the affected record's ID
-    detail        JSONB NOT NULL DEFAULT '{}',-- structured, allowlisted fields only
-    ip_hash       TEXT,
-    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
+| Term | Meaning |
+| --- | --- |
+| Administrator | A staff identity with one role, password plus TOTP, and admin-only sessions |
+| Website account | An optional service identity, not a vault identity |
+| Desktop connection | A revocable device token linking one installed app to a website account |
+| Feature flag | A runtime value, such as registration mode or an availability gate |
+| Release candidate | A signed pipeline submission with immutable artifact evidence |
+| Release record | An accepted candidate plus mutable publication, rollout, update, and kill-switch controls |
+| Support request | A secret-filtered text conversation owned by a guest email or website account |
+| Audit entry | An append-only record of an administrative mutation |
 
-CREATE INDEX IF NOT EXISTS sesame_admin_audit_log_admin_idx
-    ON sesame_admin_audit_log(admin_id, created_at DESC);
-CREATE INDEX IF NOT EXISTS sesame_admin_audit_log_action_idx
-    ON sesame_admin_audit_log(action, created_at DESC);
-CREATE INDEX IF NOT EXISTS sesame_admin_audit_log_target_idx
-    ON sesame_admin_audit_log(target_type, target_id);
+Support replies appear in the signed-in account portal. Email is queued only
+for accounts that opted in. Delivery state is separate from portal visibility.
+See [SUPPORT.md](../../SUPPORT.md) for the full support lifecycle.
 
--- Feature flags. Runtime toggles read by the Go API on each request.
-CREATE TABLE IF NOT EXISTS sesame_feature_flags (
-    key         TEXT PRIMARY KEY,             -- e.g. "registration_mode", "sync_enabled", "public_download"
-    value       TEXT NOT NULL,                -- stored as string; API parses per flag
-    updated_by  TEXT REFERENCES sesame_admin_accounts(id),
-    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
+## Route and schema references
 
--- Seed the flags that currently live as env vars or constants,
--- so they become runtime-configurable from the dashboard.
-INSERT INTO sesame_feature_flags (key, value) VALUES
-    ('registration_mode', 'invite'),
-    ('cloud_sync_available', 'false'),
-    ('public_download', 'false')
-ON CONFLICT (key) DO NOTHING;
+The generated [OpenAPI inventory](../../openapi/openapi.json) lists routes,
+authentication, availability, and handler ownership. [API.md](../../API.md)
+documents the closed request and response contracts. From the repository root:
+
+```powershell
+npm run openapi:generate
+npm run openapi:check
 ```
 
-### Column additions to existing tables
+The portal has Overview, Support, Users, Feature flags, Releases, Product
+plans, Administrators, Audit log, and System views. The API enforces every
+permission independently of those role-filtered links.
 
-```sql
--- Allow support to suspend user accounts without deleting them.
-ALTER TABLE sesame_accounts
-    ADD COLUMN IF NOT EXISTS suspended_at TIMESTAMPTZ,
-    ADD COLUMN IF NOT EXISTS suspended_reason TEXT;
+## Explicit non-capabilities
 
--- Track which admin granted beta access, for audit.
-ALTER TABLE sesame_accounts
-    ADD COLUMN IF NOT EXISTS beta_granted_by TEXT REFERENCES sesame_admin_accounts(id),
-    ADD COLUMN IF NOT EXISTS beta_granted_at TIMESTAMPTZ;
-```
+The administration app cannot:
 
-## API endpoints
-
-All under `/v1/admin/*`. All require a valid admin session cookie + CSRF token. All mutations are audited. All reject vault-shaped request bodies (same `DisallowUnknownFields` + body-size limits as the public API).
-
-### Admin auth
-
-| Method | Path | Role | Description |
-|---|---|---|---|
-| POST | `/v1/admin/auth/login` | public | Email + password + TOTP code. Issues admin session cookie. |
-| POST | `/v1/admin/auth/logout` | any | Revokes current session. |
-| GET | `/v1/admin/auth/me` | any | Returns admin email, role, MFA status. |
-| POST | `/v1/admin/auth/mfa/setup` | any | Generates TOTP secret, returns QR URI. |
-| POST | `/v1/admin/auth/mfa/verify` | any | Verifies TOTP code, marks MFA active. |
-
-### Admin management (super admin only)
-
-| Method | Path | Role | Description |
-|---|---|---|---|
-| GET | `/v1/admin/admins` | super | List admin accounts. |
-| POST | `/v1/admin/admins` | super | Invite a new admin (email + role). Sends setup link. |
-| PATCH | `/v1/admin/admins/{id}` | super | Change role or suspend/unsuspend. |
-| DELETE | `/v1/admin/admins/{id}` | super | Remove admin account. |
-
-### User management
-
-| Method | Path | Role | Description |
-|---|---|---|---|
-| GET | `/v1/admin/users?query=&page=` | super, support, billing, readonly | Paginated list. Search by email or ID. |
-| GET | `/v1/admin/users/{id}` | super, support, billing, readonly | Full detail: email, verified, beta, suspended, sessions, devices, created. |
-| POST | `/v1/admin/users/{id}/beta` | super, support | Grant beta access. |
-| DELETE | `/v1/admin/users/{id}/beta` | super, support | Revoke beta access. |
-| POST | `/v1/admin/users/{id}/suspend` | super, support | Suspend account (sets `suspended_at`, blocks login). |
-| DELETE | `/v1/admin/users/{id}/suspend` | super, support | Unsuspend account. |
-| DELETE | `/v1/admin/users/{id}` | super | Delete account (cascade). |
-| DELETE | `/v1/admin/users/{id}/sessions` | super, support | Revoke all user sessions. |
-| DELETE | `/v1/admin/users/{id}/devices/{deviceId}` | super, support | Revoke a connected device. |
-
-### Feature flags
-
-| Method | Path | Role | Description |
-|---|---|---|---|
-| GET | `/v1/admin/flags` | super, ops, readonly | List all flags. |
-| PATCH | `/v1/admin/flags/{key}` | super, ops | Update a flag value. |
-
-### Releases
-
-| Method | Path | Role | Description |
-|---|---|---|---|
-| GET | `/v1/admin/releases` | super, ops, readonly | List all release records. |
-| PUT | `/v1/admin/releases/{platform}` | super, ops | Update release metadata (version, URL, SHA256, available, signed, message). |
-
-### Product plans
-
-| Method | Path | Role | Description |
-|---|---|---|---|
-| GET | `/v1/admin/plans` | super, billing, readonly | List all plans. |
-| PATCH | `/v1/admin/plans/{id}` | super, billing | Update plan fields (name, price, description, available, includes). |
-
-### System
-
-| Method | Path | Role | Description |
-|---|---|---|---|
-| GET | `/v1/admin/system/health` | super, ops, readonly | API version, DB status, uptime, active session count. |
-| GET | `/v1/admin/system/rate-limits` | super, ops, readonly | Recent rate-limit activity (aggregated counts, no IPs). |
-| GET | `/v1/admin/system/config` | super, ops, readonly | Trusted proxies, registration mode, session TTL, current flag overrides. |
-| PATCH | `/v1/admin/system/config` | super, ops | Update trusted proxies, registration mode. |
-
-### Audit log
-
-| Method | Path | Role | Description |
-|---|---|---|---|
-| GET | `/v1/admin/audit?admin=&action=&from=&to=&page=` | super, readonly | Full audit log, filterable. |
-| GET | `/v1/admin/audit/me` | any | Own actions only. |
-| GET | `/v1/admin/audit/export` | super, readonly | CSV export of filtered log. |
-
-## Audit log actions
-
-Every mutation writes one audit row. Actions follow a `noun.verb` pattern:
-
-| Action | Target type | Target ID | Example detail |
-|---|---|---|---|
-| `user.beta.grant` | account | user ID | `{"email": "...", "reason": "beta tester"}` |
-| `user.beta.revoke` | account | user ID | `{"email": "..."}` |
-| `user.suspend` | account | user ID | `{"reason": "abuse"}` |
-| `user.unsuspend` | account | user ID | `{}` |
-| `user.delete` | account | user ID | `{"email": "..."}` |
-| `user.sessions.revoke` | account | user ID | `{"count": 3}` |
-| `user.device.revoke` | device | device ID | `{"account": "...", "deviceName": "..."}` |
-| `flag.update` | flag | flag key | `{"from": "invite", "to": "public"}` |
-| `release.publish` | release | platform | `{"version": "0.2.0", "signed": true}` |
-| `plan.update` | plan | plan ID | `{"field": "price", "from": "15", "to": "19"}` |
-| `config.update` | system | config key | `{"field": "trusted_proxies", "from": [...], "to": [...]}` |
-| `admin.create` | admin | admin ID | `{"email": "...", "role": "support"}` |
-| `admin.role.change` | admin | admin ID | `{"from": "support", "to": "ops"}` |
-| `admin.suspend` | admin | admin ID | `{}` |
-| `admin.delete` | admin | admin ID | `{"email": "..."}` |
-
-Detail fields are allowlisted. No free text beyond a short `reason` string (max 200 chars, ASCII only).
-
-## Frontend structure
-
-```
-admin/src/
-  main.ts
-  App.svelte
-  app.css                      (shared tokens from website/ or its own)
-  lib/
-    api.ts                     (fetch wrapper, CSRF, admin session)
-    auth.ts                    (login, MFA, session store)
-    types.ts
-    stores/
-      session.ts               (admin session state)
-  routes/
-    Login.svelte               (email + password + TOTP)
-    MfaSetup.svelte            (QR + verification)
-    Dashboard.svelte           (overview: user count, recent signups, flagged accounts, system health)
-    Users.svelte               (searchable table)
-    UserDetail.svelte          (profile, sessions, devices, beta, suspend/delete actions)
-    Flags.svelte               (feature flag toggles)
-    Releases.svelte            (release metadata editor)
-    Plans.svelte               (product plan editor)
-    AuditLog.svelte            (filterable table + CSV export)
-    Admins.svelte              (admin list, invite, role assignment)
-    System.svelte              (health, rate limits, config)
-    Settings.svelte            (own admin account, MFA, password change)
-```
-
-### Routing
-
-Simple client-side routing (same `window.location.pathname` approach as the website). A sidebar with role-filtered navigation: a billing admin never sees the Flags or Releases links.
-
-### Dashboard overview
-
-The landing page after login. It shows:
-- Total user count, new signups this week
-- Active beta testers, pending email verifications
-- Suspended accounts count
-- Active admin sessions
-- System health (API up, DB up, version)
-- Recent audit entries (last 10 actions)
-- Current feature flag state (registration mode, sync, public download)
-
-## Security model
-
-### Auth boundary
-- Admin auth is completely separate from user auth. Different cookie name (`sesame_admin_session`), different session table, different middleware.
-- Admin sessions last 8 hours, versus 30 days for user sessions. No "remember me" option.
-- MFA (TOTP) is required before any action. An admin without MFA is redirected to setup on first login and can only set up MFA, nothing else.
-- Admin login is rate-limited at 5 attempts per minute per email + IP.
-- Suspended admin accounts cannot log in.
-
-### Vault-blind
-- The admin API follows the same vault-blind rules as the public API. No endpoint accepts or returns vault data, credentials, TOTP seeds, backup codes, or vault identifiers.
-- User detail returns only account-level fields: email, email verified, beta access, suspended status, session count, device list (device ID + name + connected date + expiry). It never returns vault contents.
-- Audit log detail fields are allowlisted and cannot contain user secrets.
-
-### Network
-- The admin app is served from `admin.usesesame.app` (separate origin) or `usesesame.app/admin` (subpath). The Go API only accepts admin requests from the configured admin origin.
-- CSRF protection: double-submit token, same pattern as the public API.
-- All admin routes are behind the admin session middleware. No admin route is public.
-- Trusted proxy rules apply the same as the public API.
-
-### Audit
-- Every mutation writes an audit row before returning success. If the audit write fails, the action fails (fail-closed).
-- The audit log is append-only. No endpoint deletes or edits rows.
-- Super admins and read-only auditors can export the full log. Other roles see only their own actions.
-
-### First admin bootstrap
-- The first super admin is created via a CLI command, rather than via the API:
-  ```
-  go run ./cmd/adminctl bootstrap email@usesesame.app
-  ```
-- This generates a one-time setup link printed to stdout. The link expires after 1 hour. Opening the link consumes it: the enrollment secret is returned once, and finishing the password and MFA setup must happen within 30 minutes of that first open. After that window, or after setup completes, the link is spent and `adminctl reset` issues a fresh one.
-
-## Implementation phases
-
-### Phase A: auth + user read (minimum viable)
-1. Migration `0006_admin_dashboard.sql`.
-2. Admin store (`backend/internal/admin/store.go`).
-3. Admin auth middleware + login/logout/me endpoints.
-4. CLI bootstrap command for the first admin.
-5. Admin frontend: login, MFA setup, dashboard overview, user list, user detail (read-only).
-6. Audit logging for all actions.
-
-**Exit gate:** a super admin can log in with MFA, search users, view user details, and every action is in the audit log.
-
-### Phase B: user management
-1. Suspend/unsuspend, beta grant/revoke, session revoke, device revoke endpoints.
-2. Account deletion (super only).
-3. Frontend actions on the user detail page.
-4. Suspended account check in the public login endpoint.
-
-**Exit gate:** support can suspend a user, revoke their sessions and devices, and the user cannot log in until unsuspended.
-
-### Phase C: flags + releases + plans
-1. Feature flag store + endpoints. Go API reads flags from DB instead of env vars for the configurable values.
-2. Release metadata CRUD.
-3. Plan CRUD.
-4. Frontend: flags page, releases page, plans page.
-
-**Exit gate:** an ops admin can flip `registration_mode` from `invite` to `public` without a redeploy, and the public API reflects the change immediately.
-
-### Phase D: system + admin management
-1. System health, rate-limit metrics, config editor.
-2. Admin CRUD (super only): invite, role change, suspend, delete.
-3. Frontend: system page, admins page.
-
-**Exit gate:** a super admin can invite a support agent, who can log in and help users, and every action by both is in the audit log.
-
-### Phase E: polish
-1. CSV export of audit log.
-2. Pagination on all list endpoints.
-3. Keyboard navigation and a11y pass.
-4. Dark mode (reuse tokens from the desktop app).
-5. Rate-limit charts on the system page.
-
-## What the admin dashboard does NOT do
-
-- It cannot open, read, edit, or decrypt a user's vault.
-- It cannot see vault contents, passwords, TOTP seeds, backup codes, or recovery details.
-- It cannot send a user's vault to another device.
-- It cannot create or revoke a user's master password or recovery kit.
-- It cannot impersonate a user on the website.
-- It does not have access to the desktop app's local files or session.
-
-These are hard boundaries enforced by the vault-blind API design, and not only by policy.
+- receive or decrypt a vault, vault password, PIN, recovery kit, wrapping key,
+  or saved TOTP seed;
+- reset a local vault credential or impersonate a vault owner;
+- add a device to a vault or enable Sync for a shipping client;
+- manufacture updater, Sigstore, or Authenticode evidence;
+- change trusted proxy ranges at runtime.

--- a/web/admin/README.md
+++ b/web/admin/README.md
@@ -1,20 +1,23 @@
 # Sesame admin portal
 
-This subtree is the operations interface for the vault-blind Sesame account
-API, and it builds on its own. It belongs to the future `sesame-server`
-release boundary, yet it stays inside the monorepo during Phase 1.
+This is the operations interface for the vault-blind Sesame account API. It
+builds independently of the Go service.
 
-The portal owns its Node version, package lock, commands, lint and TypeScript
-configuration, design-token snapshot, browser tests, and future-repository CI
-entry point. Its build does not read the desktop, website, extension, root
-design files, or root package metadata.
+It owns its Node version, lockfile, commands, lint and TypeScript settings,
+and design-token snapshot. Its build does not read the desktop, public website,
+browser extension, or repository-root package metadata.
 
 ```powershell
 npm ci
 $env:VITE_SESAME_API_URL='https://api.test.invalid'
-npm run ci
+npm run release:check
 ```
 
-The tests use fictional data and intercept API requests. They do not start the
-Go API or create an administrator. The deployed portal remains a separate
-origin and must receive an HTTPS API origin at build time.
+`npm run ci` runs design-token, lint, and type checks. `npm run release:check`
+also creates the production bundle. There are no browser specs yet, so
+`npm run test` prints a skip notice. The deployed portal needs an HTTPS API
+origin and must use a separate origin.
+
+See [README-ADMIN.md](README-ADMIN.md) for the current domain and security
+boundaries. The generated route inventory is
+[openapi/openapi.json](../../openapi/openapi.json).


### PR DESCRIPTION
## Summary

- require the pepper used for identity rate-limit keys
- resolve client addresses through trusted proxy hops
- use the signed-in account email for support intake
- align server and administration documentation with shipped behavior

## Validation

- npm run ci

## Security and data boundary

The API remains vault-blind. No endpoint accepts vault data, recovery material, or local-vault credentials.