### PR TITLE
Serve the Linux platform in the product status

### DIFF
--- a/internal/httpapi/public_routes.go
+++ b/internal/httpapi/public_routes.go
@@ -41,7 +41,7 @@ func (a *api) productStatus(response http.ResponseWriter, request *http.Request)
 	}
 	writeJSON(response, http.StatusOK, map[string]any{
 		"phase":                      phase,
-		"platforms":                  []string{"windows"},
+		"platforms":                  []string{"windows", "linux"},
 		"accountRequired":            false,
 		"webSignInAvailable":         a.config.Accounts != nil,
 		"desktopConnectionAvailable": hasDesktopStore(a.config.Accounts),


### PR DESCRIPTION
One line: the status payload now reports windows and linux, matching the 0.2.0 desktop release. Releases endpoints stay per-platform until Linux artifacts publish.

Merges with the 0.2.0 release PR (usesesame/sesame-desktop#39).

Checks: `go build ./...`, `go vet ./internal/httpapi`, `go test ./...` (1 package, ok).