### PR TITLE
Test the closed sync routes

### DIFF
--- a/internal/httpapi/sync_closed_test.go
+++ b/internal/httpapi/sync_closed_test.go
@@ -1,0 +1,36 @@
+package httpapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSyncRoutesStayClosedWithoutTheSyncStore(t *testing.T) {
+	handler := New(Config{
+		AllowedOrigin: "https://account.example.invalid",
+		AdminOrigin:   "https://admin.example.invalid",
+	})
+	routes := []struct{ method, path string }{
+		{http.MethodPost, "/v1/sync/enroll/begin"},
+		{http.MethodPost, "/v1/sync/enroll/finish"},
+		{http.MethodGet, "/v1/sync/devices"},
+		{http.MethodDelete, "/v1/sync/devices/device-123456789012"},
+		{http.MethodPost, "/v1/sync/devices/device-123456789012/approve"},
+		{http.MethodPost, "/v1/sync/devices/device-123456789012/deny"},
+		{http.MethodPost, "/v1/sync/devices/device-123456789012/rekey"},
+		{http.MethodGet, "/v1/sync/key-package"},
+		{http.MethodPost, "/v1/sync/activate"},
+		{http.MethodPost, "/v1/sync/reset"},
+		{http.MethodGet, "/v1/sync/envelope"},
+		{http.MethodPost, "/v1/sync/envelope"},
+	}
+	for _, route := range routes {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(route.method, route.path, nil))
+		if response.Code != http.StatusForbidden || !strings.Contains(response.Body.String(), "sync_unavailable") {
+			t.Fatalf("%s %s without a sync store = %d %s", route.method, route.path, response.Code, response.Body.String())
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- The shipping API builds no sync store. The test pins that every /v1/sync route answers 403 sync_unavailable in that configuration, before any authentication work.
- Test-only.

## Verification
- `npm run ci` passed: release and deploy contracts, OpenAPI 121 operations, vet, build, Go tests. Database-backed suites skip without a local Postgres and run in CI.

## Risk
- None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage ensuring sync-related endpoints return `403 Forbidden` with a clear unavailable status when sync is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->