### PR TITLE
Require user verification for passkey ceremonies

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -348,7 +348,7 @@ func buildPasskeys(origin, rpID, rpName string) *webauthn.WebAuthn {
 		RPOrigins:     []string{origin},
 		AuthenticatorSelection: protocol.AuthenticatorSelection{
 			ResidentKey:      protocol.ResidentKeyRequirementRequired,
-			UserVerification: protocol.VerificationPreferred,
+			UserVerification: protocol.VerificationRequired,
 		},
 	})
 	if err != nil {

--- a/cmd/api/passkey_test.go
+++ b/cmd/api/passkey_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/go-webauthn/webauthn/protocol"
+)
+
+func TestPasskeyConfigurationRequiresUserVerification(t *testing.T) {
+	wa := buildPasskeys("https://account.example.invalid", "account.example.invalid", "Fictional account")
+	if wa == nil {
+		t.Fatal("passkeys unavailable")
+	}
+	_, session, err := wa.BeginDiscoverableLogin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.UserVerification != protocol.VerificationRequired {
+		t.Fatal("login must require user verification")
+	}
+}

--- a/internal/httpapi/passkey.go
+++ b/internal/httpapi/passkey.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 
 	"usesesame.app/backend/internal/accounts"
@@ -59,7 +60,9 @@ func (a *api) passkeyRegisterBegin(response http.ResponseWriter, request *http.R
 	if !ok {
 		return
 	}
-	creation, session, err := wa.BeginRegistration(waUser)
+	selection := wa.Config.AuthenticatorSelection
+	selection.UserVerification = protocol.VerificationRequired
+	creation, session, err := wa.BeginRegistration(waUser, webauthn.WithAuthenticatorSelection(selection))
 	if err != nil {
 		writeError(response, http.StatusServiceUnavailable, "passkey_unavailable", "Sesame could not start passkey registration.")
 		return
@@ -118,7 +121,7 @@ func (a *api) passkeyLoginBegin(response http.ResponseWriter, request *http.Requ
 	if !ok {
 		return
 	}
-	assertion, session, err := wa.BeginDiscoverableLogin()
+	assertion, session, err := wa.BeginDiscoverableLogin(webauthn.WithUserVerification(protocol.VerificationRequired))
 	if err != nil {
 		writeError(response, http.StatusServiceUnavailable, "passkey_unavailable", "Sesame could not start passkey sign-in.")
 		return
@@ -312,7 +315,7 @@ func (a *api) takeCeremony(response http.ResponseWriter, request *http.Request) 
 		return "", webauthn.SessionData{}, false
 	}
 	var session webauthn.SessionData
-	if json.Unmarshal(data, &session) != nil {
+	if json.Unmarshal(data, &session) != nil || session.UserVerification != protocol.VerificationRequired {
 		writeError(response, http.StatusBadRequest, "passkey_ceremony_expired", "That passkey request expired. Try again.")
 		return "", webauthn.SessionData{}, false
 	}

--- a/internal/httpapi/passkey_database_test.go
+++ b/internal/httpapi/passkey_database_test.go
@@ -1,0 +1,147 @@
+package httpapi
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/go-webauthn/webauthn/webauthn"
+	"usesesame.app/backend/internal/accounts"
+)
+
+func TestPasskeyVerificationWithDatabaseSessions(t *testing.T) {
+	databaseURL := os.Getenv("SESAME_TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("SESAME_TEST_DATABASE_URL is required")
+	}
+	ctx := context.Background()
+	store, err := accounts.Open(ctx, databaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	wa, err := webauthn.New(&webauthn.Config{RPID: passkeyTestRP, RPDisplayName: "Fictional account", RPOrigins: []string{passkeyTestOrigin}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name      string
+		flags     byte
+		oldPolicy bool
+		expired   bool
+		status    int
+	}{
+		{"verified", 5, false, false, http.StatusOK},
+		{"unverified", 1, false, false, http.StatusUnauthorized},
+		{"old policy", 5, true, false, http.StatusBadRequest},
+		{"expired", 5, false, true, http.StatusBadRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handle := make([]byte, 16)
+			if _, err := rand.Read(handle); err != nil {
+				t.Fatal(err)
+			}
+			accountID := hex.EncodeToString(handle)
+			_, err := store.DB().ExecContext(ctx, `INSERT INTO sesame_accounts (id, email, password_hash) VALUES ($1, $2, $3)`, accountID, accountID+"@example.invalid", "fictional-unused-hash")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if _, err := store.DB().ExecContext(ctx, `DELETE FROM sesame_accounts WHERE id = $1`, accountID); err != nil {
+					t.Error(err)
+				}
+			})
+			c := newPasskeyTestClient(t)
+			c.handler = New(Config{AllowedOrigin: passkeyTestOrigin, Accounts: store, Passkeys: wa})
+			c.store.credential.ID = handle
+			credential, err := json.Marshal(c.store.credential)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := store.AddCredential(ctx, accountID, handle, credential, "Fictional passkey"); err != nil {
+				t.Fatal(err)
+			}
+			begin := c.request("/v1/auth/passkey/login/begin", nil)
+			if begin.Code != http.StatusOK {
+				t.Fatalf("begin status %d", begin.Code)
+			}
+			cookie := c.cookies["sesame_wan"]
+			if cookie == nil {
+				t.Fatal("ceremony cookie missing")
+			}
+			ceremonyID, err := base64.RawURLEncoding.DecodeString(cookie.Value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if _, err := store.DB().ExecContext(ctx, `DELETE FROM sesame_webauthn_sessions WHERE id = $1`, ceremonyID); err != nil {
+					t.Error(err)
+				}
+			})
+			var data []byte
+			if err := store.DB().QueryRowContext(ctx, `SELECT data FROM sesame_webauthn_sessions WHERE id = $1`, ceremonyID).Scan(&data); err != nil {
+				t.Fatal(err)
+			}
+			var session webauthn.SessionData
+			if err := json.Unmarshal(data, &session); err != nil {
+				t.Fatal(err)
+			}
+			if session.UserVerification != "required" {
+				t.Fatal("stored ceremony must require user verification")
+			}
+			c.challenge = session.Challenge
+			if tc.oldPolicy {
+				session.UserVerification = "preferred"
+				data, err = json.Marshal(session)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := store.DB().ExecContext(ctx, `UPDATE sesame_webauthn_sessions SET data = $2 WHERE id = $1`, ceremonyID, data); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tc.expired {
+				if _, err := store.DB().ExecContext(ctx, `UPDATE sesame_webauthn_sessions SET expires_at = NOW() - INTERVAL '1 minute' WHERE id = $1`, ceremonyID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			var body map[string]any
+			if err := json.Unmarshal(c.body(false, tc.flags, passkeyTestOrigin, false), &body); err != nil {
+				t.Fatal(err)
+			}
+			body["response"].(map[string]any)["userHandle"] = base64.RawURLEncoding.EncodeToString(handle)
+			encoded, err := json.Marshal(body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			response := c.request("/v1/auth/passkey/login/finish", encoded)
+			if response.Code != tc.status {
+				t.Fatalf("finish status %d, want %d", response.Code, tc.status)
+			}
+			var sessions int
+			if err := store.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM sesame_sessions WHERE account_id = $1`, accountID).Scan(&sessions); err != nil {
+				t.Fatal(err)
+			}
+			want := 0
+			if tc.status == http.StatusOK {
+				want = 1
+			}
+			if sessions != want {
+				t.Fatalf("stored %d account sessions, want %d", sessions, want)
+			}
+			if tc.status != http.StatusOK && c.cookies["sesame_session"] != nil {
+				t.Fatal("rejected login set a session cookie")
+			}
+			if !tc.expired {
+				if _, _, err := store.TakeWebAuthnSession(ctx, ceremonyID); err == nil {
+					t.Fatal("ceremony survived its first use")
+				}
+			}
+		})
+	}
+}

--- a/internal/httpapi/passkey_test.go
+++ b/internal/httpapi/passkey_test.go
@@ -1,0 +1,315 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/go-webauthn/webauthn/webauthn"
+	"usesesame.app/backend/internal/accounts"
+)
+
+const passkeyTestOrigin = "https://account.example.invalid"
+const passkeyTestRP = "account.example.invalid"
+
+type passkeyTestStore struct {
+	accounts.Store
+	accounts.PasskeyStore
+	accounts.AccountSecurityStore
+	credential    webauthn.Credential
+	ceremony      []byte
+	ceremonyID    []byte
+	ceremonyOwner string
+	expires       time.Time
+	sessions      int
+	registrations int
+	updateError   error
+	suspended     bool
+}
+
+func (s *passkeyTestStore) SaveWebAuthnSession(_ context.Context, id []byte, owner string, data []byte, expires time.Time) error {
+	s.ceremony, s.ceremonyID, s.ceremonyOwner, s.expires = data, id, owner, expires
+	return nil
+}
+
+func (s *passkeyTestStore) TakeWebAuthnSession(_ context.Context, id []byte) (string, []byte, error) {
+	if !bytes.Equal(s.ceremonyID, id) || s.ceremony == nil || time.Now().After(s.expires) {
+		return "", nil, accounts.ErrNotFound
+	}
+	data := s.ceremony
+	s.ceremony = nil
+	return s.ceremonyOwner, data, nil
+}
+
+func (s *passkeyTestStore) FindByID(context.Context, string) (accounts.User, string, error) {
+	return accounts.User{ID: "01020304", Email: "fictional@example.invalid", Suspended: s.suspended}, "", nil
+}
+
+func (s *passkeyTestStore) SessionForToken(ctx context.Context, _ []byte) (accounts.User, accounts.SessionInfo, error) {
+	user, _, err := s.FindByID(ctx, "01020304")
+	return user, accounts.SessionInfo{AuthenticatedAt: time.Now()}, err
+}
+
+func (s *passkeyTestStore) CredentialsForAccount(context.Context, string) ([]webauthn.Credential, error) {
+	return []webauthn.Credential{s.credential}, nil
+}
+
+func (s *passkeyTestStore) UpdateCredential(_ context.Context, _ []byte, data []byte) error {
+	if s.updateError != nil {
+		return s.updateError
+	}
+	return json.Unmarshal(data, &s.credential)
+}
+
+func (s *passkeyTestStore) AddCredential(_ context.Context, _ string, _ []byte, data []byte, _ string) error {
+	s.registrations++
+	return json.Unmarshal(data, &s.credential)
+}
+
+func (s *passkeyTestStore) CreateSession(context.Context, string, []byte, time.Time) error {
+	s.sessions++
+	return nil
+}
+
+type passkeyTestClient struct {
+	t         *testing.T
+	handler   http.Handler
+	store     *passkeyTestStore
+	private   ed25519.PrivateKey
+	cookies   map[string]*http.Cookie
+	challenge string
+	peer      string
+}
+
+func newPasskeyTestClient(t *testing.T) *passkeyTestClient {
+	t.Helper()
+	wa, err := webauthn.New(&webauthn.Config{
+		RPID: passkeyTestRP, RPDisplayName: "Fictional account", RPOrigins: []string{passkeyTestOrigin},
+		AuthenticatorSelection: protocol.AuthenticatorSelection{UserVerification: protocol.VerificationPreferred},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := cbor.Marshal(map[int]any{1: 1, 3: -8, -1: 6, -2: []byte(public)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &passkeyTestStore{credential: webauthn.Credential{ID: []byte("fictional-credential"), PublicKey: key, AttestationType: "none"}}
+	address := [16]byte{0x20, 0x01, 0x0d, 0xb8}
+	copy(address[4:], public[:12])
+	return &passkeyTestClient{t: t, handler: New(Config{AllowedOrigin: passkeyTestOrigin, Accounts: store, Passkeys: wa}), store: store, private: private, cookies: map[string]*http.Cookie{}, peer: netip.AddrPortFrom(netip.AddrFrom16(address), 12345).String()}
+}
+
+func (c *passkeyTestClient) request(path string, body []byte) *httptest.ResponseRecorder {
+	c.t.Helper()
+	request := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	request.RemoteAddr = c.peer
+	request.Header.Set("Origin", passkeyTestOrigin)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Sesame-CSRF", "fictional-csrf")
+	request.AddCookie(&http.Cookie{Name: "sesame_csrf", Value: "fictional-csrf"})
+	for _, cookie := range c.cookies {
+		request.AddCookie(cookie)
+	}
+	response := httptest.NewRecorder()
+	c.handler.ServeHTTP(response, request)
+	for _, cookie := range response.Result().Cookies() {
+		if cookie.MaxAge < 0 {
+			delete(c.cookies, cookie.Name)
+		} else {
+			c.cookies[cookie.Name] = cookie
+		}
+	}
+	return response
+}
+
+func (c *passkeyTestClient) begin(registration bool) {
+	c.t.Helper()
+	path := "/v1/auth/passkey/login/begin"
+	if registration {
+		path = "/v1/account/passkey/register/begin"
+		c.cookies["sesame_session"] = &http.Cookie{Name: "sesame_session", Value: "fictional-session"}
+	}
+	response := c.request(path, nil)
+	if response.Code != http.StatusOK {
+		c.t.Fatalf("begin status %d", response.Code)
+	}
+	var session webauthn.SessionData
+	if err := json.Unmarshal(c.store.ceremony, &session); err != nil {
+		c.t.Fatal(err)
+	}
+	if session.UserVerification != protocol.VerificationRequired {
+		c.t.Fatal("ceremony must require user verification")
+	}
+	c.challenge = session.Challenge
+}
+
+func (c *passkeyTestClient) body(registration bool, flags byte, origin string, invalidSignature bool) []byte {
+	c.t.Helper()
+	ceremonyType := "webauthn.get"
+	if registration {
+		ceremonyType = "webauthn.create"
+	}
+	client, err := json.Marshal(map[string]any{"type": ceremonyType, "challenge": c.challenge, "origin": origin, "crossOrigin": false})
+	if err != nil {
+		c.t.Fatal(err)
+	}
+	rpHash := sha256.Sum256([]byte(passkeyTestRP))
+	auth := append([]byte(nil), rpHash[:]...)
+	auth = append(auth, flags)
+	auth = binary.BigEndian.AppendUint32(auth, 1)
+	encode := base64.RawURLEncoding.EncodeToString
+	response := map[string]any{"clientDataJSON": encode(client)}
+	if registration {
+		auth = append(auth, make([]byte, 16)...)
+		auth = binary.BigEndian.AppendUint16(auth, uint16(len(c.store.credential.ID)))
+		auth = append(auth, c.store.credential.ID...)
+		auth = append(auth, c.store.credential.PublicKey...)
+		attestation, err := cbor.Marshal(map[string]any{"fmt": "none", "attStmt": map[string]any{}, "authData": auth})
+		if err != nil {
+			c.t.Fatal(err)
+		}
+		response["attestationObject"] = encode(attestation)
+	} else {
+		clientHash := sha256.Sum256(client)
+		signed := append(append([]byte(nil), auth...), clientHash[:]...)
+		signature := ed25519.Sign(c.private, signed)
+		if invalidSignature {
+			signature[0] ^= 1
+		}
+		response["authenticatorData"] = encode(auth)
+		response["signature"] = encode(signature)
+		response["userHandle"] = encode([]byte{1, 2, 3, 4})
+	}
+	body, err := json.Marshal(map[string]any{"id": encode(c.store.credential.ID), "rawId": encode(c.store.credential.ID), "type": "public-key", "response": response})
+	if err != nil {
+		c.t.Fatal(err)
+	}
+	return body
+}
+
+func TestPasskeyLoginRequiresCurrentUserVerification(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		flags            byte
+		origin           string
+		invalidSignature bool
+		setup            func(*passkeyTestClient)
+		status           int
+	}{
+		{name: "verified", flags: 5, status: http.StatusOK},
+		{name: "unverified", flags: 1, status: http.StatusUnauthorized},
+		{name: "previously verified credential", flags: 1, setup: func(c *passkeyTestClient) { c.store.credential.Flags.UserVerified = true }, status: http.StatusUnauthorized},
+		{name: "missing presence", flags: 4, status: http.StatusUnauthorized},
+		{name: "invalid signature", flags: 5, invalidSignature: true, status: http.StatusUnauthorized},
+		{name: "wrong origin", flags: 5, origin: "https://other.example.invalid", status: http.StatusUnauthorized},
+		{name: "expired ceremony", flags: 5, setup: func(c *passkeyTestClient) { c.store.expires = time.Now().Add(-time.Minute) }, status: http.StatusBadRequest},
+		{name: "old preferred ceremony", flags: 5, setup: func(c *passkeyTestClient) { c.changeStoredPolicy(protocol.VerificationPreferred) }, status: http.StatusBadRequest},
+		{name: "malformed ceremony", flags: 5, setup: func(c *passkeyTestClient) { c.store.ceremony = []byte("invalid") }, status: http.StatusBadRequest},
+		{name: "persistence failed", flags: 5, setup: func(c *passkeyTestClient) { c.store.updateError = errors.New("fictional storage failure") }, status: http.StatusServiceUnavailable},
+		{name: "suspended", flags: 5, setup: func(c *passkeyTestClient) { c.store.suspended = true }, status: http.StatusLocked},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newPasskeyTestClient(t)
+			c.begin(false)
+			if tc.setup != nil {
+				tc.setup(c)
+			}
+			origin := tc.origin
+			if origin == "" {
+				origin = passkeyTestOrigin
+			}
+			response := c.request("/v1/auth/passkey/login/finish", c.body(false, tc.flags, origin, tc.invalidSignature))
+			if response.Code != tc.status {
+				t.Fatalf("status %d, want %d", response.Code, tc.status)
+			}
+			if tc.status == http.StatusOK {
+				if c.store.sessions != 1 || c.cookies["sesame_session"] == nil {
+					t.Fatal("verified login must create a session")
+				}
+			} else if c.store.sessions != 0 || c.cookies["sesame_session"] != nil {
+				t.Fatal("rejected login created a session")
+			}
+		})
+	}
+}
+
+func (c *passkeyTestClient) changeStoredPolicy(policy protocol.UserVerificationRequirement) {
+	c.t.Helper()
+	var session webauthn.SessionData
+	if err := json.Unmarshal(c.store.ceremony, &session); err != nil {
+		c.t.Fatal(err)
+	}
+	session.UserVerification = policy
+	data, err := json.Marshal(session)
+	if err != nil {
+		c.t.Fatal(err)
+	}
+	c.store.ceremony = data
+}
+
+func TestPasskeyLoginConsumesCeremonyOnSuccessAndFailure(t *testing.T) {
+	for _, flags := range []byte{1, 5} {
+		c := newPasskeyTestClient(t)
+		c.begin(false)
+		cookie := c.cookies["sesame_wan"]
+		body := c.body(false, flags, passkeyTestOrigin, false)
+		c.request("/v1/auth/passkey/login/finish", body)
+		count := c.store.sessions
+		c.cookies["sesame_wan"] = cookie
+		response := c.request("/v1/auth/passkey/login/finish", body)
+		if response.Code != http.StatusBadRequest || c.store.sessions != count {
+			t.Fatal("consumed ceremony was accepted")
+		}
+	}
+}
+
+func TestPasskeyRegistrationRequiresUserVerification(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		flags     byte
+		oldPolicy bool
+		status    int
+	}{
+		{"verified", 0x45, false, http.StatusCreated},
+		{"unverified", 0x41, false, http.StatusBadRequest},
+		{"missing presence", 0x44, false, http.StatusBadRequest},
+		{"old preferred ceremony", 0x45, true, http.StatusBadRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newPasskeyTestClient(t)
+			c.begin(true)
+			if tc.oldPolicy {
+				c.changeStoredPolicy(protocol.VerificationPreferred)
+			}
+			response := c.request("/v1/account/passkey/register/finish", c.body(true, tc.flags, passkeyTestOrigin, false))
+			if response.Code != tc.status {
+				t.Fatalf("status %d, want %d", response.Code, tc.status)
+			}
+			want := 0
+			if tc.status == http.StatusCreated {
+				want = 1
+			}
+			if c.store.registrations != want {
+				t.Fatalf("saved %d credentials, want %d", c.store.registrations, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Passkey registration and login now request user verification, and the finish handlers reject a stored ceremony that was created under the previous weaker policy. An assertion without a current user-verification flag creates no session and sets no account session cookie.
- A rejected or consumed ceremony can never be replayed, and the stored ceremony must carry the required policy.

## Verification

```text
go test ./internal/httpapi ./cmd/api -run Passkey -count=1   passed, including the PostgreSQL-backed ceremony cases
npm run ci        passed
npm run test:race passed
```

The new tests cover verified and unverified assertions, missing user presence, invalid signatures, a wrong origin, stale and reused ceremonies, old-policy ceremonies, suspended accounts, credential-persistence failure, and session counts in PostgreSQL.

## Risk

- Authenticators that cannot verify the user no longer qualify on their own for passwordless login. Ceremonies started before deployment are rejected and must restart. Reverting the commit restores the previous behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Passkey registration and sign-in now require user verification, such as a PIN or biometric authentication.
  * Passkey ceremonies with outdated or weakened verification requirements are rejected.

* **Bug Fixes**
  * Prevented reuse of completed passkey ceremonies and rejected expired, malformed, or invalid authentication attempts.

* **Tests**
  * Added comprehensive coverage for passkey verification, registration, sign-in, database-backed sessions, and related failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->